### PR TITLE
feat: implement comprehensive endnotes support

### DIFF
--- a/005-analysis.md
+++ b/005-analysis.md
@@ -1,0 +1,219 @@
+# Demonstration of DOCX support in calibre
+
+This document demonstrates the ability of the calibre DOCX Input plugin to convert the various typographic features in a Microsoft Word (2007 and newer) document. Convert this document to a modern ebook format, such as AZW3 for Kindles or EPUB for other ebook readers, to see it in action.
+
+There is support for images, tables, lists, footnotes, endnotes, links, dropcaps and various types of text and paragraph level formatting.
+
+To see the DOCX conversion in action, simply add this file to calibre using the **“Add Books” **button and then click “**Convert”. ** Set the output format in the top right corner of the conversion dialog to EPUB or AZW3 and click **“OK”**.
+
+# Text Formatting
+
+## Inline formatting
+
+Here, we demonstrate various types of inline text formatting and the use of embedded fonts.
+
+Here is some **bold, ***italic, ****bold-italic, ***<u>underlined </u>and ~~struck out ~~ text. Then, we have a super<sup>script</sup> and a sub<sub>script</sub>. Now we see some red, green and blue text. Some text with a yellow highlight. Some text in a box. Some text in inverse video.
+
+A paragraph with styled text: subtle emphasis  followed by strong text and intense emphasis. This paragraph uses document wide styles for styling rather than inline text properties as demonstrated in the previous paragraph — calibre can handle both with equal ease.
+
+## Fun with fonts
+
+This document has embedded the Ubuntu font family. The body text is in the Ubuntu typeface, here is some text in the Ubuntu Mono typeface, notice how every letter has the same width, even i and m. Every embedded font will automatically be embedded in the output ebook during conversion.
+
+## **Paragraph level formatting**
+
+You can do crazy things with paragraphs, if the urge strikes you. For instance this paragraph is right aligned and has a right border. It has also been given a light gray background.
+
+For the lovers of poetry amongst you, paragraphs with hanging indents, like this often come in handy. You can use hanging indents to ensure that a line of poetry retains its individual identity as a line even when the screen is  too narrow to display it as a single line. Not only does this paragraph have a hanging indent, it is also has an extra top margin, setting it apart from the preceding paragraph.
+
+# Tables
+
+| ITEM | NEEDED |
+| --- | --- |
+| Books | 1 |
+| Pens | 3 |
+| Pencils | 2 |
+| Highlighter | 2 colors |
+| Scissors | 1 pair |
+
+Tables in Word can vary from the extremely simple to the extremely complex. calibre tries to do its best when converting tables. While you may run into trouble with the occasional table, the vast majority of common cases should be converted very well, as demonstrated in this section. Note that for optimum results, when creating tables in Word, you should set their widths using percentages, rather than absolute units.  To the left of this paragraph is a floating two column table with a nice green border and header row.
+
+Now let’s look at a fancier table—one with alternating row colors and partial borders. This table is stretched out to take 100% of the available width.
+
+| City or Town | Point A | Point B | Point C | Point D | Point E |
+| --- | --- | --- | --- | --- | --- |
+| Point A | — |  |  |  |  |
+| Point B | 87 | — |  |  |  |
+| Point C | 64 | 56 | — |  |  |
+| Point D | 37 | 32 | 91 | — |  |
+| Point E | 93 | 35 | 54 | 43 | — |
+
+Next, we see a table with special formatting in various locations. Notice how the formatting for the header row and sub header rows is preserved.
+
+| College | New students | Graduating students | Change |
+| --- | --- | --- | --- |
+|  | Undergraduate |  |  |
+| Cedar University | 110 | 103 | +7 |
+| Oak Institute | 202 | 210 | -8 |
+|  | Graduate |  |  |
+| Cedar University | 24 | 20 | +4 |
+| Elm College | 43 | 53 | -10 |
+| Total | 998 | 908 | 90 |
+
+Source: Fictitious data, for illustration purposes only
+
+Next, we have something a little more complex, a nested table, i.e. a table inside another table. Additionally, the inner table has some of its cells merged. The table is displayed horizontally centered.
+
+|  | One Three | Two |  | Four | To the left is a table inside a table, with some cells merged. |
+| --- | --- | --- | --- | --- | --- |
+| One Three | Two |
+|  | Four |
+
+We end with a fancy calendar, note how much of the original formatting is preserved. Note that this table will only display correctly on relatively wide screens. In general, very wide tables or tables whose cells have fixed width requirements don’t fare well in ebooks.
+
+| December 2007 |
+| --- |
+| Sun |  | Mon |  | Tue |  | Wed |  | Thu |  | Fri |  | Sat |
+|  |  |  |  |  |  |  |  |  |  |  |  | 1 |
+|  |  |  |  |  |  |  |  |  |  |  |  |  |
+| 2 |  | 3 |  | 4 |  | 5 |  | 6 |  | 7 |  | 8 |
+|  |  |  |  |  |  |  |  |  |  |  |  |  |
+| 9 |  | 10 |  | 11 |  | 12 |  | 13 |  | 14 |  | 15 |
+|  |  |  |  |  |  |  |  |  |  |  |  |  |
+| 16 |  | 17 |  | 18 |  | 19 |  | 20 |  | 21 |  | 22 |
+|  |  |  |  |  |  |  |  |  |  |  |  |  |
+| 23 |  | 24 |  | 25 |  | 26 |  | 27 |  | 28 |  | 29 |
+|  |  |  |  |  |  |  |  |  |  |  |  |  |
+| 30 |  | 31 |  |  |  |  |  |  |  |  |  |  |
+
+# Structural Elements
+
+Miscellaneous structural elements you can add to your document, like footnotes, endnotes, dropcaps and the like.
+
+## Footnotes & Endnotes
+
+Footnotes[^2] and endnotes<sup>2</sup> are automatically recognized and both are converted to endnotes, with backlinks for maximum ease of use in ebook devices.
+
+## Dropcaps
+
+# D
+
+rop caps are used to emphasize the leading paragraph at the start of a section. In Word it is possible to specify how many lines of text a drop-cap should use. Because of limitations in ebook technology, this is not possible when converting.  Instead, the converted drop cap will use font size and line height to simulate the effect as well as possible. While not as good as the original, the result is usually tolerable. This paragraph has a “D” dropcap set to occupy three lines of text with a font size of 58.5 pts. Depending on the screen width and capabilities of the device you view the book on, this dropcap can look anything from perfect to ugly.
+
+## Links
+
+Two kinds of links are possible, those that refer to an external website and those that refer to locations inside the document itself. Both are supported by calibre. For example, here is a link pointing to the [calibre download page](http://calibre-ebook.com/download). Then we have a link that points back to the section on paragraph level formatting in this document.
+
+## Table of Contents
+
+There are two approaches that calibre takes when generating a Table of Contents. The first is if the Word document has a Table of Contents itself. Provided that the Table of Contents uses hyperlinks, calibre will automatically use it. The levels of the Table of Contents are identified by their left indent, so if you want the ebook to have a multi-level Table of Contents, make sure you create a properly indented Table of Contents in Word.
+
+If no Table of Contents is found in the document, then a table of contents is automatically generated from the headings in the document. A heading is identified as something that has the Heading 1 or Heading 2, etc. style applied to it. These headings are turned into a Table of Contents with Heading 1 being the topmost level, Heading 2 the second level and so on.
+
+You can see the Table of Contents created by calibre by clicking the Table of Contents button in whatever viewer you are using to view the converted ebook.
+
+Demonstration of DOCX support in calibre	1
+
+Text Formatting	2
+
+Inline formatting	2
+
+Fun with fonts	2
+
+Paragraph level formatting	2
+
+Tables	3
+
+Structural Elements	5
+
+Footnotes & Endnotes	5
+
+Dropcaps	5
+
+Links	5
+
+Table of Contents	5
+
+Images	7
+
+Lists	8
+
+Bulleted List	8
+
+Numbered List	8
+
+Multi-level Lists	8
+
+Continued Lists	8
+
+# Images
+
+Images can be of three main types. Inline images are images that are part of the normal text flow, like this image of a green dot . Inline images do not cause breaks in the text and are usually small in size. The next category of image is a floating image, one that “floats “ on the page and is surrounded by text. Word supports more types of floating images than are possible with current ebook technology, so the conversion maps floating images to simple left and right floats, as you can see with the left and right arrow images on the sides of this paragraph.
+![dot_green.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAFvUlEQVR42u2WfVBUVRTAz/vYt2/ZBYRVTCAEP0gFv3IEJTUFRBmpNHXGUccUGxPLsskv1JJKpbAmR0vSSSVHzRk0rWQ0FCQrERwTFdT8AmXle0Xc7/d23+u8R4sw7jM/dqb+6DJnz+Pce8/53XPuu/cRoijCv9mI/wH+UwCZR1T/ND4EZRLKBJQuKIP+tpehNKLkoRxAuf0wJ+njec8Aaw8rAgxBSdOqA+dGdI6D7oExoFH5Q2ddD7mzyXwDbHwL3LxTCpVNJ8HiuLMNzdkoZzw5W5msALAmrxVg6tC5bbbc09uytOqAJUPDp0OvrsPB6WoCHsUpmEAUHa1OCDXQpC+oqM5Ao1yrL4bTVXsQpHk9+lrazpesV01QAPjwJ0bW02JTYW/JdumfDeH6wWnx/eaBS2gAzlUPgmBHs9K+IYAkWWCorkCRQVB4cStUGc9KmViEPjn0KY9a/RLnGWD1wVaA6XGpsOfk9s3RoaPTYnumgMNpAF5oeUjgB0FUpD+o6VAouX4Iyg1F2ehzAfpsXehEBYBV3zPux6wwfd8lidEzgXPW4upNjxi4Y6OwLAzdDY6V74Jbxkvr0SSXY82rCgArctWSivFR+5ZMjp0PJGHHet99ouDupqI6gSCysL/ka7A6TLFoKl031eEZYOleGWDHiD5jZ0d26481b3yMtCuXg6G6wJXaC/Db5aM5aJiTNU0B4L3d6ggd63dj8rCZuJk4TL3tKYO7S6HBzcvA/lO7wGy/1+PzGY5KjwCLdrLLo8OiMmN6v4BpM3th9fezQBI6KL36O5TfqkjfMMv+iUeAhTvYgsRBo+LDg3oisXdW724kZqGq4TocKztRuGmOPcEjQNo3rGHKyAkhAdpAPGS4JwqkmAOCgWbLHdj3a97t7NftoR4B5m3ROGYlTGRYhsHke/eSIvDPznGws+Agt/UNm9ojQOpXGsfspFcYkMN7H0D6zcn/gdv+pgLAaxt9DNMTxoewjAo3ocurACRBYQZ42FNw5Pa3b1s9l2DGFz75KcPjxgbr9XjZ8E8USKnRpApqjEY4VHzy6O53rUkeAaZ95rP8+cjIzJi+ffAItnsVgKFZKL10Gf64ciV972Kr59dw6qfaEJ2GNcxOTsIjmMMsOL20ehqPZAZyDueD2WYPzV1maftg6QAwaZ1WUpvjhwxMi44IAxtnBW8cxRrGB8orb0HhmXPS1bzgwArL/d72AC9/LAP017Ls+dSUROx1gYN/ulKoVSyugYIdeQW4etsANF348X0FgJQMnfsxs0dw1+WTxwzDTy0r7gfHYwV1N4ZW46ebD+w/fgpu1NRLdU+X7IcyzJ4Bkj/QtZ+/aVDviLfGDx8ol0LKxKOeDdI7L61cSv2R4nNQdrXySzQvdPcf/kgBYNxKHeSvsxAZGRlETU0NVaX/bmOvZ4PmT4kfBi7gEcSCm/Phr6eKUmFgLVCggn2Fp+BadcMWqmzEOzqdzpmbmyskrdCKP69VAEhM94WR7GLSaDSq6urqpA3h3xJ2YhWj41OTYgfA4Oe640cpJ2eDc0nXtSDPo0gS73xGXjWN+uyfNyG/5DxwFiYnoPrFTEEQ7rEsa6qurnYUFRW5xHZBOwAkLPMFfWUyhYNZnucDse8ZgiCC7DpDlE1XNU7dyR7fLyIUJPH1YUHv7yvPM7aYwGS1w8VKgyyOu+xxjTn8KGsOvYzBjeijDnUTDjVjFnhFgDFLfWG0tmMGSJL0Q61BTdvZ+iCrtmqUk7kXJxJCoEDw3aR5pKiqJUSqmeb8irXW8F8Ya5cGDOpE4Vwul+mRMyABFK03t+2B2tpalZ+fH41jKMwIQdM06XQ6aXRKMwxDoCbccymKkhyhycXjGEGj0Qg4R6qRy2w28+49MHqJTjyedf8j9wEAd5NAJC3BuG0VFRVEY2MjERkZKduam5vb+gICAsTg4GARx4hRUVFtTnG+/CwFdtvaA/wF5UDY3/sPE+wAAAAASUVORK5CYII=)
+
+![back.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABmJLR0QA/wD/AP+gvaeTAAASCklEQVR4nO2deWwc133HP2/24LG8JFG3eVqSLVuW5CjxLVu2Jaek7TQw4iStEaBIgwYF0gYo2lSxjUJIGol2mgYJYORoESAwXCOqm6TW4TiXXcdN0tyJj0gmRVI8RFK8dpfcJZe7M7/+sVxyuZzdnV3uRXI+wGDneDPz5v2+7zfvmrdgY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY7MmaHmo40Cx41AMnMWOQNF59LSjabrri2IYm4DHih2dQqMVOwLFZOsDn/c0By79l1Lqb4odl2Kxbj1Ac/vT2yDyIvCeYselmKxLATS2nbwBjLNAy8JOUVXFi1HxWHevgOaHTh3RlHodpGXJASXTRYpSUVlXAmhpP/kRDF4GNmia4sbrGosdpaKzbgTQ/GDHPwnqm4Db5XLywJF3cd1uWwBrvgxw6NDXXONbJ76OyF8AeCrLee+Rg2yoq8Lrny1y7IrPmhZA69GO2jH3xAsKjgLUb6jm2D0HqKwsBwGHQxU7ikVnzQqg9eGORl2Xcwr2AVyzcxP33b4Pl9sFUuzYlQ5rUgBND3/uXUZEzijFDoDrdzVw+6FdaJoDZNH+4YhRxFiWBmtOAE1/crIdQ30LRRUK3nNgF/uub0JTUXd/ZTxArcdNRdmae/SsWFO1gOa2jr9WmnpRCVUOTePeO/axf2/U+IYI3UN+Lo9MRT2AgIj9Llgj2UBUU9tTT6Pk7wHcbidHDx9g+5YNCKDrBp2DPrzTofngdjEgxqoXQPORE+XieepZJfIBgOrqCt5790FqazwIEI7oXOjzEpgNLzvXFsEqF8Ceh/+lfk4P/7cSuQNg86Yajh0+QHlFGQIEZ8Nc6PcyF9aXnCcIIoL9BljFAmh96OndISN8XsEugOaGzRy+9UZcrugj+aZDdA56iejLrWwbfpFVKYDGtpN36ob+XQX1APuua+TdB3ehaRoiwphvlu4hf8pCngi2EliFAmhp7/igIN8EylFw6817uOG6hoVS/eBogIGx9B17gthlAFaZAJrbTn5KkA5AOZ0ad9+2j+aGzYhEM3PPkJ9R30za68Qyvu0AVosAHj3taA50PQPq4wDlZS6O3n2QzZtqEAFdFzoHvfgCc5YuZxcAFyl5Adx45ERVIHDpNKg2gNqaSo7dfYDqqkoA5sIGF/onmQlFMr62/RIocQE0vO+pHYGIcRa4GWDb5lruu+sAZWXRDp1AKMw7/V7msmjTX+4B1J83t59yrTzW+UJe7z3/+JdzfdWSFUBre8dNRsQ4BzQAtDZt5c5b9uKc79DxBkJ0DfrQjcxzsTCf+5ef+uhK451Hlrdk5YCSFEBL+1PHDIwXgBqAm/Y2c2h/KwqFAKPeGXpH/Nm/x2XJz7qm5ATQ1Hbqo4LxVcClKbjt3XvZ07od5o0/MDrNlfHAiu4Ry/21VeX82SNHFtoLZDHAYjiWvy4WaxGLB8TSeUvDJzsev/vc935q7aGypIQEIKqp/dRnFDwJ4HRqHLljPw3bN80nlnBpyM9EDoZxSZz3X5LoaQwYvy/VeWbnxoc3v665CPNNSQjgxkdPuIPBjm+IqMcAPBVu7r/7IBvrqhEgMt+bNxW0Vs1Lx/RMmFBc/0C8QRJrBgvHEg2aQiTR/QnXMblXsvCeclfBaihFF0Djg6c2BAJ8B7gHoK6uiqN37afKUwHA7FyEzgEfM3OZV/OSsdJXSL7ZXAueCmdB2iqKKoCmhz/bonTOAXsBdmzbyJHb9+F2uxARArMROge9627oVrS3sjD3KpoAWh566hbRjReBrQC7W7Zz26Hr0TSFiDA5HaJ7yI+RRTVvrbBmPUBz28n3i2E8B1QC3HxTK/v3Ni8cH5mcoX90al03165ZD9Dc3vFJkC8ADk1T3PmevbQ2bQOiD90/Os3IZLDQ0SoporWUtVYIfPS0ozlw6QsgnwRwuZzce+c+tm/ZCIBuCD3DfianQgWLUqmzZl4BOx4+UekOdD8HvB+gsrKCY4f3U1frASCsG3QO+EzH7a1HFtoK1oIAWt73ua0SUS+C3AKwcUM199+1n8qKMgBm5qt5oYRxe+ua+JaqPJNXATQ9+NReici52Lf4DTvqOXzbDbic0dtOBcN0XTEft7feKVRVMG8CaG47eQ9ifAfYALBn105uPbh7ftweC9U8++MMc1Z1LaCp7dRjKL4BuAHetX8X+65viPbmCQxPBhkYXZcTcliikFki5wJoae94UpDPAMqhadxx6w20NGwBAQOh7+o0o9704/bWM2a9jfkiZwI4dOhrrvFtE18VkY9C9POs++7az5ZNdSDRal73kM/yuL31jkhhWgJyIoBdbSdqxtX4C4g6BlDtqeD+ew5Q45kftxfR6Rr0Ecxi3N56pVCvgRUL4NoH/rkhohzngJsA6utrufeOm6gocyMIs3M6nYO+ZZ9n2aRmVRQCm9pO3azDWYhOxNBwzRYO37IXp8OBIEwFw3QP+exqXoYUsmaUtQCa2jra0OQ0QhXA3j2NHNp/LUpF67Dj/lkuj0zb1bwsKVS6ZSWA5vaOj4M8g+BAwS0H93Ddrp1A1HUNTwRLftBFKZNkEFJeyFgArQ93NBq6nAIcAPV1HrZtrsM/NRP9Pk/BW90j67ord6Xo4TLKyxyl2RfQfeZ4X2Pbybs0pZ0FaRmbDPDL377DgX2tOOebeFu319A14M1qzL4NRCI6EUdh7pXVHEF9Lz3+tnLqt4P8AmBo1MvPf32B4MwsAtR6yriheRNu55qagqigxD54zTdZW6jnxSdG5hxz9yJ8B8DrD/KzX17A55sCoNzt5IbmTVSWl/DXViVKuhHHuWRFWfTKmRPB3ltDHwC+CDATmuPnv7nI1dEJAFxOB9c1bKCuqmzlMV1PLOT+/Ctg5W+aV18Vb+ePXq7dfWxMwXsNQ7Thq17cTo2amko0pairLiOiC0F7wIclylwOnPPT2I6Njsd2v+Ht/NG3c32vnL2kL58//oyGvF8U04YIb73Tz8WufnQjOqS7YUsV12yuQtnT81qi5MsAZnSff/wsmnEPwhWAnr6rvPFWN5GIjghsrqukZXstmmarIBWxIWGrTgAAl8888RuHrt8GvAEwPOrl17+/yGwoOtizptLNrp11uOwaQkqkQLMY5cUKl77/ZH+ZU7sT+D6Azz/Dr35zkempAAJUlDnZtXMD5e6if5lWkiw0A69GDxDj4ov/ONUcDD0o8O8AM6Ewv/z9O0xM+BABl1Pj2p21VFe68xWFVUtsRHAhPEBe25t6e181fJ0/OlO3+1gIuN8wRF0d9eJ2OaiqqkQpRa2njIhu5PTjz9WO2+lY+DOLibGJ2O7SrgWkovf88Q6F+jAwa4hwoWuAnp6Bhe/+ttd72LbRU4iorBpWbSEwGT3nj582RI4KjAH0Doxy4WIPuh4dKLKxppyGLdUL8/qvZ9LNJZBLCloU73vp8f916twOdAKMjPn4/ZudzIXmEIGqCjeNW6txOtZ5DWF+HsNVWwtIxaWXP90V0ctuE8XrAP6pGX73h06CwSAglLudNG2rwe0qUHdYiZJkFrOcU5SsNvDy3024DM9R4HmI1hD+8GYXk5N+AJwORdPW6nXbkVSgbgCgiH8Z0/XS34Z6zx9/TCk5CdE/cHr7Qi8jI+OIgFKKnfUeajzrs5pYoG9Di/2fQUp6zj3+hAh/CYQNETq7B+jrH5pvDFFs3VBJfW1FcaNZYKI1AFldH4ashMsvffobrQ+e6jOEF4DagcFRZmdDXNvSgNI06qrKcDo0rk4GMXKQKFs3Vi4UNJfMEBY/j1+KKeMW1xePJYaPO7zsGksKeMuDL04Zt1bLAGZ0n/v0Dx3KuAvoAxgb9/PHCz1EImEEqCx3sr3egyMHHUmJ08Un5rZkxl80dNRBx7aXGT+uJU8SwpkZP+buY/FYDJd/SsIDxLh07ok3m9ufvlWhnxU45J8O8tbb3eze1Uh5RTlup4Md9VWMTASymiA6xqIxBP903HQ0ZrkY85xoWk1LEi7xmssmkUxxLN+UlAAAes9/anjrA5+/p8IR+Q8U75uZneOtP/awZ3cDVVVVOB0aWzd6GPPNZDVFfAwRIaIbXO7uy2HsVx8l8wqIZ+T7/xDorbr2EeDLALquc/HiZcbHJxERHJpic10lVRXZVhPt0coxSs4DLPCfH9R74ZPN7R3dIF8wRBzdPYPMzobYvmMLoNhYU4FD0/AFMp9YyrStXXE8F1HPB8rQ3s7LdfNx0VzT3N7xpyDPAR6ATRtraGzcASrqwIKzESamZiy/P+trK3A6NMIRg4t/fGd+rzzfe/7xjyQETXbFxP2r1qWU5CsgDgWo3vPHzyhdvw8YBhif8NN1qY9wJFoGqChzUF9baXmoWawAt7TKJopo93hs0RK2k+03244tihLPZKUigFhCxRIuMXG1npef/K0x57sT5G2AqakgXe/0MjsbQgC3S1vI2elYmIBpSb5dIoCVGH9Z3FkujpIRRrEEkGhss99l+/p+2DEY7HvjPpBXAGZDc3R29hIIBBEBpyMqAisdScteF1EPkCjAbIyf7LnSPWtRBFEoAcTn8EQ3mWwxzUVX33x+yvvT04+IoT8L0e/ourv68E56ERGUgo3V5VSUpSjfzjfmJNTjE18BmeT0ZLndzNBWnrlgHiKfAkh069kY3TSM1/s7/fL3nvyEroc+C4ghQl/fEKMjY8S+R63xuPEk6U0062cXlpUBMnHzluJtIYzZklcx5EMAMaPHGz/ZutnDpvMCC7/9L5/418is/+NACGB4ZIwrA1eQ+Y9RPBUuajxu049RllUDlxcCszV+utxv9fnN1nMuhFwKwIrBkz1UJjliiUAGfnzq22H/wAdAJgEmJ/1c7h1A16Mfo5S5nNR6ypYMNUtsw5/fm1gITObms83JqQyeTdrlhFwIIP4hlMl24nqmD57WGwy+/swvgkNvPIgYvQDTgSA9l/oJz80BgsupUVvlXlJNNGnHV1jL9VZyu5k4MskI6dIxZx5hpQJQFpfEyCcTRNYe4+pvn+/1d/7wITEivwIIhUL0dl9mJhBtINKURp0n2q1sPu5+oRZgpVqXjxxtNc3MlqzJVgBWI2ZVEFY9RsplousV3/DPvv5hIxw6B9F/G7vcN4Df548aW0F1pWuxS3lJX3zKhqB0uTuVGDLN0StZMmYlHiDxpokRyWQ7E/WbJeJCQod8/eG+H3R8Qp+d+gqAGMKVwWEmxyeIakAt9tPHP42YNgRZMWwqo2Zi4GzS0MwOGZGNANIZPlUYK+dYEUgaQczS/+OTnw9PDT8hoAOMXh1nZHgYI27ARcI3COm8jJVcnKmB85F+GbFSD5Bun9m21X2pwlgSy+BPvvSt0ET3x0QkAODzTjE0MIgYBiIszF0AxHuAVO/lTI2ar7RIpKAeYFUx/PN/+0mg/1cfEtGHAQKBGfr6BgiH7dlKYGUCMOsCTddNajbaOdm+VGEkYZ+kWsbe/PaFic4fPCJG+G2AcGiOK30DhGbi/odYKSH6ujDml5TXTHLvlTxTJuclknV3dDYCSGeMVGGsnGPJqHGLkWJ9YZnq+p/h8f/75ockEnoFIKLrDF0ZSnwuI8WS7n4rFUuu0i8jVuoBrBow3XYqo1oxuGGyHr/ogDE9eWnq8mtf/JgxF3g2GoO46C96AD3+HJPF7H6ZxtuqQLL1NpZJ32+aH1K5tXTrqfaZ/S5dj4R0X/drP/Zcc2ja4ao4zHwBSgyjz3fp1e+yNJGTiS3THG9lPZNjqQSRESstBFpJiFSJlipXpcptqVx1fA5OXF/YHnzl6a/OTQ//VexBFASShSW9V0gVR6vrmXqMFRsfclMLMItsuvdyJgllZthUv2mNH1uuvPals6HJ3jZERlGIhXOyiUs2wk6XjvHbKyLXr4BMXHn8ei7cu9m+ZNsLy/TAr684a+vPOMs3bvF3v/ZTzBPZikGyWdLFPdV6Tsi6ASGDa5s1miQeT3YsWbhkYRLXzbYzJTHBMxVzsjBWhW12nZyRTwGY3SedAKz8Wl03286WTEUQv57Nb16NHk+hBGB230wMnW6fle2VkkoE8dupRGC2L2/u3QrFEkAi2YrA6na6/YkkM4RVEcSvWy3zFIVSEUAyimH8GPkSQUlR6gJIR76MHyNbEdjY2NjY2NjY2NjY2JQo/w/sD2v/gUCEtgAAAABJRU5ErkJggg==)
+
+The final type of image is a “block” image, one that becomes a paragraph on its own and has no text on either side. Below is a centered green dot.
+
+Centered images like this are useful for large pictures that should be a focus of attention.
+![dot_green.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAFvUlEQVR42u2WfVBUVRTAz/vYt2/ZBYRVTCAEP0gFv3IEJTUFRBmpNHXGUccUGxPLsskv1JJKpbAmR0vSSSVHzRk0rWQ0FCQrERwTFdT8AmXle0Xc7/d23+u8R4sw7jM/dqb+6DJnz+Pce8/53XPuu/cRoijCv9mI/wH+UwCZR1T/ND4EZRLKBJQuKIP+tpehNKLkoRxAuf0wJ+njec8Aaw8rAgxBSdOqA+dGdI6D7oExoFH5Q2ddD7mzyXwDbHwL3LxTCpVNJ8HiuLMNzdkoZzw5W5msALAmrxVg6tC5bbbc09uytOqAJUPDp0OvrsPB6WoCHsUpmEAUHa1OCDXQpC+oqM5Ao1yrL4bTVXsQpHk9+lrazpesV01QAPjwJ0bW02JTYW/JdumfDeH6wWnx/eaBS2gAzlUPgmBHs9K+IYAkWWCorkCRQVB4cStUGc9KmViEPjn0KY9a/RLnGWD1wVaA6XGpsOfk9s3RoaPTYnumgMNpAF5oeUjgB0FUpD+o6VAouX4Iyg1F2ehzAfpsXehEBYBV3zPux6wwfd8lidEzgXPW4upNjxi4Y6OwLAzdDY6V74Jbxkvr0SSXY82rCgArctWSivFR+5ZMjp0PJGHHet99ouDupqI6gSCysL/ka7A6TLFoKl031eEZYOleGWDHiD5jZ0d26481b3yMtCuXg6G6wJXaC/Db5aM5aJiTNU0B4L3d6ggd63dj8rCZuJk4TL3tKYO7S6HBzcvA/lO7wGy/1+PzGY5KjwCLdrLLo8OiMmN6v4BpM3th9fezQBI6KL36O5TfqkjfMMv+iUeAhTvYgsRBo+LDg3oisXdW724kZqGq4TocKztRuGmOPcEjQNo3rGHKyAkhAdpAPGS4JwqkmAOCgWbLHdj3a97t7NftoR4B5m3ROGYlTGRYhsHke/eSIvDPznGws+Agt/UNm9ojQOpXGsfspFcYkMN7H0D6zcn/gdv+pgLAaxt9DNMTxoewjAo3ocurACRBYQZ42FNw5Pa3b1s9l2DGFz75KcPjxgbr9XjZ8E8USKnRpApqjEY4VHzy6O53rUkeAaZ95rP8+cjIzJi+ffAItnsVgKFZKL10Gf64ciV972Kr59dw6qfaEJ2GNcxOTsIjmMMsOL20ehqPZAZyDueD2WYPzV1maftg6QAwaZ1WUpvjhwxMi44IAxtnBW8cxRrGB8orb0HhmXPS1bzgwArL/d72AC9/LAP017Ls+dSUROx1gYN/ulKoVSyugYIdeQW4etsANF348X0FgJQMnfsxs0dw1+WTxwzDTy0r7gfHYwV1N4ZW46ebD+w/fgpu1NRLdU+X7IcyzJ4Bkj/QtZ+/aVDviLfGDx8ol0LKxKOeDdI7L61cSv2R4nNQdrXySzQvdPcf/kgBYNxKHeSvsxAZGRlETU0NVaX/bmOvZ4PmT4kfBi7gEcSCm/Phr6eKUmFgLVCggn2Fp+BadcMWqmzEOzqdzpmbmyskrdCKP69VAEhM94WR7GLSaDSq6urqpA3h3xJ2YhWj41OTYgfA4Oe640cpJ2eDc0nXtSDPo0gS73xGXjWN+uyfNyG/5DxwFiYnoPrFTEEQ7rEsa6qurnYUFRW5xHZBOwAkLPMFfWUyhYNZnucDse8ZgiCC7DpDlE1XNU7dyR7fLyIUJPH1YUHv7yvPM7aYwGS1w8VKgyyOu+xxjTn8KGsOvYzBjeijDnUTDjVjFnhFgDFLfWG0tmMGSJL0Q61BTdvZ+iCrtmqUk7kXJxJCoEDw3aR5pKiqJUSqmeb8irXW8F8Ya5cGDOpE4Vwul+mRMyABFK03t+2B2tpalZ+fH41jKMwIQdM06XQ6aXRKMwxDoCbccymKkhyhycXjGEGj0Qg4R6qRy2w28+49MHqJTjyedf8j9wEAd5NAJC3BuG0VFRVEY2MjERkZKduam5vb+gICAsTg4GARx4hRUVFtTnG+/CwFdtvaA/wF5UDY3/sPE+wAAAAASUVORK5CYII=)
+
+![forward.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABmJLR0QA/wD/AP+gvaeTAAARxklEQVR4nO2deWwc133Hv29m9uJKNHWSusilJEuyJOuIYtlOLFipm1ikpCRtaqc2WsQuWhdtWvRwakkRmgpIQspOareJiyKHkQBFWsNG06CKJMtHmthq5ChRA9eRK9c1RVIiubtckkty7zl+/WN2lsPR3jtvl/bOh3/MmzdvZn47v+87580j4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODwnqC790td2+474W60HQsNodEG1AsN0ofjce8LnQf7lzTaloVE0whAhz4iAK8FDvQHGm3JQqHJBACAsA0Crq7vffyDjTZlIdB8AsiiQftx98G+jzfajkbTtAIA4Cdi3+8+ePJPG21II2lKAaxqXwKvxwUAIhF9LdDb/yROnGjKZ9GUP7qjYzkOffQ2tLa2GFF/EbjofX7tfU/6GmlXI2hKARABrYtbcOiePWhf0WbE/qYUT//Hho99ZWVDjaszTSkAACAieNxu3Lt/N7o7243o21VJ/mn3gcc3N9K2etKUAiACQAABEAQBd+3diltvCWSPsg0kqD/tPti3r3EW1o+mFACgO5+IQEQQBIYPbO/GnXs2Q2AMAFtKxF4K9PY/0Gg7edO8AiACAIxOxKERgcCwcf0a7P/wdrgkEQA8AL7X1XPy8420kzdNKQAC5cKTs2m8fS0KRdUAEFZ3LMev79+FFp8bABhj9OWu3v5v7d9/QmqUvTxpSgEAejsgWwgglpRx5doU0rIKAFjW1oqP3r0bbTf5AQAM+P1Bn/uHmz/++OJG2cuLphSA4XhzSZDKqLgyHEU8JYMIWORvwT37dqHD6CYydm9a0c5v7Hl8bQNM5kZTCgDQnU80P05RNbwzMo1oPA0CweN24e4P3Yr1gQ4jyQ6ZaRe6D53cWW97edG8AjCcbxGBphEGgzMYjyYBAIIo4rbdm7Htli4AAAPWkkavBXr7D9TRXG40pwCMKoAKHCZgJBLHSETvITAA27d04fYPbIKgP7HFBJzq7un7g/oYzI/mFAAKO9/M+HQSQ6FZaEQAMQQ6V2HfHTvgkkQwQCLGvhno7esHiPG3mA9NKQAy/ZViJp7BwOgMZFUDgbByRRs+sm8XvD5vNgU7Gujp/+eNPV/z8LWaD00pgBxllAIAkEgrGBibQTqjdxNvavXjnrt25LqJYOy3FRZ/ae29Ty7lZCk3mlcAVLb/AQAZWcXA2AwSKQVEgM/nxd0fuhUdK3NzTPdJYvrCup4nNnCwlhu21V2Bw31boLCH7Lqe7TA8CGAdAGzbugE7tqwDEeF/r0eRyubssi7DGNYs82NxiwsAoJGGN371LgYGg0aSMEj4xODZI6/b/Au4YNvwJmnCBsboiF3X4w2V0woscN71SAwr2nxY1uoFg4Cd2zfC5/Pi8pVBgLASTPtRV2//7w6dOfav9lptP01bBehvA6s/fzyaRHAyofcQANy8fi327NwMQWAA4GPAc129fX9ph6084fKCY98d27Fu9dIbhlyLPXCiuTb5XDoyHbfGzJ1nPkDW+BvOJ3hd7soaAAWIxtKQFQ2rlrVAYAzr1qyAz+vGzy69BVlWBQb2t929feuv+jf+GZ6/v/x6po5wEYDX40KL1408frzRQZbGWDHHmfcLHS8mBJp33AYFAIinZFwLx7BmuR+iwLBsaSv23bkTF37xFpKJFAjss4H4u53Jj33lgdCLfxW35aY2wu0Vp/F4Y0l5XoT1wRd0qFUIlp1ySxXj3ELpNBt0kJZVDIdjWL3MD7dLgN/vw747tuPn/3UFU9EYABz2SvKPA71PHB4881iw1PXqCR8BZKdcAcCbAxNcbrHQUFQN1yMxdCxpgc8jwePx4PbbtuKN//4/jIUmwcA+CKivd9578uDwuaOXG22vAbdGoEkDTYOmEcYm45hNZEBEkEQJu3duRnfXKiNJlyDifFdP/6810k4zXARQqCHWDBAB4WgSU7E0CPq4wS1bAti2pRuMAQC1MYazgYN9n2mwqQB4CSA72bLpigATU7NpjEeTubZKZ1cHdu/YBEFkAOAGse8Eevv/ptEvkviNAzS3/wHoDeDQZBKqpj+M9vZl2LtnKzwuEdBHYU8Eek5+p5ELV3CrAoxp181OMqMgNJmAomogAtpuasXevbfC35J9m8jwmUTCeybwyRNtxa/EB36NQMf5OTKKhuBkAmlZBYHQ0uLF3tu2YemSRQAAIroHsuf8+sMnO+ttW9MOBdcbVSOEo0mk0iqIAJfkwq5dW9Henn2bSNimqfSzzoP9e+ppFx8BlJhy1awQESIzScSSMggEUWDYvu1mBLpWG0k6BMJP1vf2HaqXTRx7AfYNt76fINLfIUzHMyACGBg2bliLzZsCYPrbeb8G9oOu3pOfrYc9HAeCbpx27TBHLCnrYwXZzLJ2zUps33Gz0U0UGejp7oP9X+W9cAXHRiCvK79/SKYVTMymke0lYvnSNuzevRUejz5CT4RHuy96nuO5cAXnkUAeV39/kZFVTMwkoar6w2pd5Mfu3Vvh9+vdRAI+JcXSr2zs6VvB4/6c2gCO8ytBUQkTsylkFBVEBK/Hg507b8GStuyniAx3KgwX1vf2bbL73nzbAE4jsGw0jRCNpbNjBYBLkrB9+ya0ty/LpmAbNODC+gMn77LzvpyqgALTdxyKQgRMxzP6zGMQmMCweVMAnbluIluqCfRyoKf/03bdk984gPMuoGriKRnxpJLtSjN0dq7GzZsCYPrrRA8Y/iXQe/KoHffiOx/AaQhUTTKj5OYVgAjtK5dh67aNEEUBABhA/YGe/m/UunAFlxlByVQGsXgKADA9m+BxC9shO+aGcWDGLcHv1d3EmIRlS1sRHo/qBxkeGfJ7fwXg69Ven4sAZFlBRlYAAOm0zOMWTYHbJUIS9a4igTA9OYXxSDR3nBi+OHj6yNNA9bUB1wkhThVQPT6PhMX6OkXQSMNEMIxQKGJ0r2UADw+dPvYFgNX0kPnNCnZ8XzV+rwset6h3pFUNwbEgZmeNGeUsqmnqbw2/cPwVO+7FRQCO76uDMWCxzw1J0gtmRVYQHBlDIpkykgxqKg4Nnztu26xiPgIw5uM7xUDZCALDYp8bosgAAtLpFEZHxiBnlGwKughInxg+Z+93BRyrAMf55SKJAha3uPTXwQQk4jGMjYSgalo2BftBUpF+h8eXRdy/DHIojlsS4PfpzicQZqIzCIfCpkWs2N8NLlr/OV7fFnKqApxGYDl43RJajFe/IEyMT2ByYso4rDLCn189e/RpnjZwXf7UqQYK0+J1wevKtvQ1QjgYwsxMDABADDFBYw9ePXv0FG87uPUCHOfnhzFgkc8NSdSLfFlREBoJIjnX0h8j4PDVs0cv1cMeTh+Hlv5ytxkRGMOiFhdEfREJZNIZjI6Mmlr6eFMQ2aHBU0eH62UT14EgZz7AHKLAsMjnhiDozyaZSCI0OpZdpRwA8KKQYfcPvHx0up528asCHOfncEkC/F59USkiYHZmGuHguHnVk28vDy3940uX/rDuL06coWDOeFwifLmWPjAVmcDU5FSulgRwfOjMsf6hBtnHbSTQEQDQ4pHg1j8EBWkaxkPhXEsfQAqMPTx4+uizDTMQnLuBzTocxBjQ4nHBJQkgAlRNRXg0iERCX4GcgIiosd8YeOHo+QabynMgqDmdLzAGv88FgTEQAbKcQXBkDJlMrnp/RxTEgwNnHnunkXYacH0b2GwNQVFg84Z108nUvJY+MZxX3PTJkX97bMEsnMTxXYDeDti4pi3vMnDmAsK8mtdc3Pxj1rRz9ymVfs6e+en07dRsytwVqxqXJJgae4TEbByhUGhuqhnRsyyReXjk9IlUkcvUHe69AMaynzwaDjD2mJGOwLLFpXmtlJzDGJt3vcI3MiKY6RBl1+Ux3TA7gYYx+3oqbpcIn1vK2RydmMLU5KT5+v2DZ48dr3X2Dg/4TApNZxBLpOfFFf7vHJacWSSNNWy9dt7FqfIE3W4RALNFAF63BLdLyI3pT4xHMDM9YxyWidEfDZ3+/DPAsdpvxgEuAhgeGkXdxjKroGNVB5YsvQm19FIYA3xuSZ+9QwCpGkLBEBKJ3CzoaQbhvsHTR16yw2ZevC//GWJ5VD9rSWAMPo+Um72jKAqCo2PIpDNGkmEB7NDAmSNv2mcvH2wTgEgY1gjftOt6dkMCHmSERYDxtrK6NoAgMPi9Lr2lQUAqlcT4WAiyos/XYMAlTdUOD5w7Pmaf9fx4z/6zoyxW+wv9HtZ54MsPCILwTwDQvqoDbW2tAIBoLKUv41YGkqi39Bl0ESXjcYSCIfNHJaeSirQgF4UuxEKvAphlaw2Xs69DqmB8BqEvTV9Z9ndLArzuuTH92alpTExEzN3Pp4eGf/koLj+vYO57C7JsFxwLRQBWR+dzeG0ioDwrcpbpFo9LhMcl5jqyk+EIpuda+iqRcmTo7F9/PXtF0XL1ecMbRY41hEYJgKGw08t1fkUiIE3NfQVFua+Xiz9/xvRuniQKIACaqiISHkc8livh41om8XvDL3/xFG7M9eZwOSIgNEAQ9RKA2WmlHF+JMIqF5+0TafM+gyu1iJXRzct+jQtZkTE+FkI6ZYxvUEiZHf/09dee+gXKc34l27qVEDwFUMjpxRxcTo6vRBBz+6TOF0CRgSdBYPC5JQgCAxFBzmQQHhuDLBszs7UrydA794cufXcIhYv8Urm/XAFwFQMPARRzeLVCqLmNQNpcCWB0A/MhCmxuTJ8IiUQCkWAIWm5MX311auDFh6bffjWK8p1vdSgr41ixsG3YKQCG2pxvdzVh2Z/fCMxX/7skwVjJG0RAbHYGU+OR3L+VISX97Pj5Zx5NJK5loDu/1uLd7NhyHG8O2yIEOwSQz3nFHFuJ82stFXJhMlcBef6Xgdslwp39KFMjYHpyAtNTufmZpGXiTwy//KWnsvvlOr/S3G3N5axAGHnSVkWtAijk8GoFUW2JUWyrhzXthrUQjCent/SzL4dIQyQcQSJmTN2iTGZ2/NHR1576Pko7vpYcbcXq8GJULYJqBVCpw3kLpFiczg29AL2O9xmDOwSoqoLxYBjplPHKXoumIgOPBC8+8zpudH6lOR6Y79RCOboWKj6/lhLA/MDN+9U4n3uJQaY2gOF8M0pGRjg4Bjm7tA1IGY4N//yhyOV/v4r53bxCuRiWsJVSDjauVcm++TdWJZ5qBFDK8cXSlHMOn9LDWgIYDTsAmWQS4VAImjF1S5V/GX3rh49MX7s4Cd355ebiYpRyYL64UvvF0pRFrSVAqbh8++XGFUtTuTjI2gvQSczGMBEZz73QUeXkudCFb3wuEwul8thhpZJcma/Iz5emnPOsTq66+lgo7wLqilH8T09NYnpybtUtJTX97es/euqrQLr2SYLvEWoRgFX9+eKqKfbKOa/yxhObm49HRJgIhRHPtvQJUJVY8MTIq39vfKRRqIFXrMFntiFfyz7ffrlxxfYLxZVFNQIo5Yxiaaot9krZw0qEGZiQy9XR+a9x4+mpq38SfP1br1quWWhbbrhSsRQTUDXnlEWtJQBQXb1VaYu40DFzK5xZwmbbwGAuAYytNpYcfePh8BvPXSlwH2u4kFPzxVUjiEr3rdermGoFUPUNTecXKvLzhfM59oauXoGtHjaVAABAmno5evUnD02//VLIYofVTmu43NIhXxxvgVRMrY3AaorpfPGFcnGhcL5cbu0lzA8LJgFo6ptTl773qZnx/8k3dascEZjDdlQX+c6rVCxVYUcvwDCi2hxdytmoYgvrPmOiBgCanPru8H/+w3EkIsVW3SomAvN+NVu7S4yasLMbaBZCrTm6suK9cFxunwlMVdOzX7j2St8/VvibCu1XWhoYW7tKDFsoNdBhx7XzDdBYjxc6VihdoTTWcG5/0aINrljs3WpW4LBLBNa4aksJW+EpgHz3qSR3V+PwglVAjVQqAnO41mqCK/USQL771lq8l3K23b+t0nZBuXHcivdyaJQArNRcx5fYLxVvpZAjyhWBOVyO8xvGQhFAIRrhfANeIlhQLHQBlIKX8w2qFYGDg4ODg4ODg4ODg8MC5f8BW3XRXSYm8t8AAAAASUVORK5CYII=)
+
+Generally, it is not possible to translate the exact positioning of images from a Word document to an ebook. That is because in Word, image positioning is specified in absolute units from the page boundaries.  There is no analogous technology in ebooks, so the conversion will usually end up placing the image either centered or floating close to the point in the text where it was inserted, not necessarily where it appears on the page in Word.
+
+# Lists
+
+All types of lists are supported by the conversion, with the exception of lists that use fancy bullets, these get converted to regular bullets.
+
+## Bulleted List
+
+- One
+
+- Two
+
+## Numbered List
+
+1. One, with a very long line to demonstrate that the hanging indent for the list is working correctly
+
+1. Two
+
+## Multi-level Lists
+
+1. One
+
+  1. Two
+
+    1. Three
+
+    1. Four with a very long line to demonstrate that the hanging indent for the list is working correctly.
+
+    1. Five
+
+1. Six
+
+A Multi-level list with bullets:
+
+- One
+
+  - Two
+
+    - This bullet uses an image as the bullet item
+
+      - Four
+
+- Five
+
+## Continued Lists
+
+1. One
+
+1. Two
+
+An interruption in our regularly scheduled listing, for this essential and very relevant public service announcement.
+
+1. We now resume our normal programming
+
+1. Four
+
+---

--- a/005-structure.json
+++ b/005-structure.json
@@ -1,0 +1,8925 @@
+{
+  "metadata": {},
+  "elements": [
+    {
+      "type": "heading",
+      "level": 1,
+      "runs": [
+        {
+          "text": "Demonstration of DOCX support in calibre",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "This document demonstrates the ability of the calibre DOCX Input plugin to convert the various typographic features in a Microsoft Word (2007 and newer) document. Convert this document to a modern ebook format, such as AZW3 for Kindles or EPUB for other ebook readers, to see it in action.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "There is support for images, tables, lists, footnotes, endnotes, ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "links, dropcaps and ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "various",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " types of text and paragraph level formatting.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "To see the DOCX conversion in action, simply add this file to calibre using the ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "“Add Books” ",
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "button and then click “",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "Convert”. ",
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " Set the output format in the top right corner of the conversion dialog to EPUB or AZW3 and click ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "“OK”",
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ".",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": []
+    },
+    {
+      "type": "heading",
+      "level": 1,
+      "runs": [
+        {
+          "text": "Text Formatting",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Inline formatting",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Here, we demonstrate various types of inline text formatting and the use of embedded fonts.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Here is some ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "bold, ",
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "italic, ",
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "bold-italic, ",
+          "bold": true,
+          "italic": true,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "underlined ",
+          "bold": false,
+          "italic": false,
+          "underline": true,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "and ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "struck out ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": true,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " text. Then, we have a super",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "script",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": true,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " and a sub",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "script",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": true,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ". Now we see some ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "red",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "color": "#FF0000",
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ", ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "green",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "color": "#92D050",
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " and ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "blue",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "color": "#0070C0",
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " text. Some text with a ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "yellow highlight",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "backgroundColor": "#FFFF00",
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ". Some text in a",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "box",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ". Some text",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " in ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "inverse video",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "color": "##FFFFFF",
+          "backgroundColor": "#000000",
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ".",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "A paragraph with styled text: ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "subtle emphasis",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "  ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "f",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "ollowed by ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "strong text ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "a",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "nd ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "intense emphasis",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ".",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " This paragraph uses document wide styles for styling rather than inline text properties as demonstrated in the previous paragraph",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " — ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "calibre can handle both with equal ease.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Fun with fonts",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "This document has embedded the Ubuntu font family. The body text is in the Ubuntu typeface, here is ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "some text in the Ubuntu Mono typeface",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontFamily": "Ubuntu Mono",
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ", notice how every letter has the same width, even i and m",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontFamily": "Ubuntu Mono",
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ". Every embedded font will automatically be embedded in the output ebook during conversion.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Paragraph level formatting",
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "You can do crazy things with paragraphs, if the urge strikes you. For instance this paragraph is right aligned and has a right border. It has also been given a light gray background.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "alignment": "end"
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "For the lovers of poetry amongst you, paragraphs with hanging indents, like this often come in handy. You can use hanging indents to ensure that a line of poetry retains its individual identity as a line even when the screen is  too narrow to display it as a single line. Not only does this paragraph have a hanging indent, it is also has an extra top margin, setting it apart from the preceding paragraph.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "spacing": {
+        "before": 600
+      },
+      "indentation": {
+        "left": 720,
+        "hanging": 720
+      }
+    },
+    {
+      "type": "heading",
+      "level": 1,
+      "runs": [
+        {
+          "text": "Tables",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "rows": [
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "ITEM",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1818
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "NEEDED",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1620
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Books",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1818
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "1",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1620
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Pens",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1818
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "3",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1620
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Pencils",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1818
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "2",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1620
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Highlighter",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1818
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "2 colors",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1620
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Scissors",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1818
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "1 pair",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1620
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Tables in Word can vary from the extremely simple to the extremely complex. ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "calibre",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " tries to do its best when converting tables. While you may run into trouble with the occasional table, the vast majority of common cases should be converted very well, as demonstrated in this section.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " Note that for optimum results, when creating tables in Word, you should set their widths using percentages, rather than absolute units. ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " To the left of this paragraph is a floating two column table with a nice green border and header row.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Now let’s look at a fancier table—one with alternating row colors and partial borders. This table is stretched out to take 100% of the available width.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "rows": [
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "City or Town",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "fontSize": 11,
+                      "color": "#auto"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point A",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "fontSize": 11,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point B",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "fontSize": 11,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point C",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "fontSize": 11,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point D",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "fontSize": 11,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point E",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "fontSize": 11,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point A",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "—",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point B",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "87",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "—",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point C",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "64",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "56",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "—",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point D",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "37",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "32",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "91",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "—",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [],
+                  "alignment": "center"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Point E",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "93",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "35",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "54",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "43",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "—",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false,
+                      "color": "#auto"
+                    }
+                  ],
+                  "alignment": "center"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": []
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Next, we see a table with special formatting in various locations. Notice how the f",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "ormatting for the h",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "eader row and sub header rows is preserved.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "spacing": {
+        "before": 240,
+        "after": 240
+      }
+    },
+    {
+      "type": "table",
+      "rows": [
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "College",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "New students",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Graduating students",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Change",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Undergraduate",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Cedar University",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "110",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "103",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "+7",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Oak Institute",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "202",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "210",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "-8",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Graduate",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Cedar University",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "24",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "20",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "+4",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Elm College",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "43",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "53",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "-10",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Total",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "998",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "908",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "90",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ],
+                  "style": "DecimalAligned"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Source:",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " Fictitious data, for illustration purposes only",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Next",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ", we have something a little more complex, a nested table, i.e. a table inside another table. Additionally, the inner table has some of its cells merged.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " The table is displayed horizontally centered.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "spacing": {
+        "before": 240
+      }
+    },
+    {
+      "type": "table",
+      "rows": [
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 4788
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "One",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                },
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Three",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "rowspan": 1,
+              "width": 1678
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Two",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1629
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 1678
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Four",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1629
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "To the left is a table inside a table, with some cells merged.",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 4788
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "One",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                },
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Three",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "rowspan": 1,
+              "width": 1678
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Two",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1629
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 1678
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Four",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 1629
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [],
+      "spacing": {
+        "before": 240
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "W",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "e end with a ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "fancy",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " calendar, note how ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "much of the original formatting is preserved",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ".",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " Note that this table will only display correctly on relatively wide screens. In general, very wide tables or tables whose cells have fixed width requirements don’t fare well in ebooks.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "spacing": {
+        "before": 240
+      }
+    },
+    {
+      "type": "table",
+      "rows": [
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "December 2007",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "colspan": 13,
+              "width": 7500
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Sun",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "verticalAlignment": "bottom",
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              },
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "verticalAlignment": "bottom",
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Mon",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 984,
+              "verticalAlignment": "bottom",
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              },
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "verticalAlignment": "bottom",
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Tue",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "verticalAlignment": "bottom",
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              },
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "verticalAlignment": "bottom",
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Wed",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "verticalAlignment": "bottom",
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              },
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "verticalAlignment": "bottom",
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Thu",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "verticalAlignment": "bottom",
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              },
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "verticalAlignment": "bottom",
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Fri",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "verticalAlignment": "bottom",
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              },
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236,
+              "verticalAlignment": "bottom",
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "Sat",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "verticalAlignment": "bottom",
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              },
+              "margin": {
+                "left": 43,
+                "right": 43
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "1",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "2",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "3",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "4",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "5",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "6",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "7",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "8",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "9",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "10",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "11",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "12",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "13",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "14",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "15",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "16",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "17",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "18",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "19",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "20",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "21",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "22",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "23",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "24",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "25",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "26",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "27",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "28",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "29",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "bottom": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "cells": [
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "30",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": [
+                    {
+                      "text": "31",
+                      "bold": false,
+                      "italic": false,
+                      "underline": false,
+                      "strikethrough": false,
+                      "superscript": false,
+                      "subscript": false
+                    }
+                  ]
+                }
+              ],
+              "width": 984,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 222,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "width": 236,
+              "borders": {
+                "left": {
+                  "style": "single",
+                  "color": "#7F7F7F",
+                  "width": 3
+                }
+              }
+            },
+            {
+              "paragraphs": [
+                {
+                  "type": "paragraph",
+                  "runs": []
+                }
+              ],
+              "colspan": 2,
+              "width": 864,
+              "borders": {
+                "top": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 0.5
+                },
+                "right": {
+                  "style": "single",
+                  "color": "#365F91",
+                  "width": 3
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 1,
+      "runs": [
+        {
+          "text": "Structural Elements",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Miscellaneous structural elements you can add to your document, like footnotes, endnotes, dropcaps and the like. ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Footnotes & Endnotes",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Footnotes",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "2",
+          "superscript": true,
+          "_footnoteRef": "2"
+        },
+        {
+          "text": " and endnotes",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "2",
+          "superscript": true
+        },
+        {
+          "text": " are automatically recognized and both are converted to endnotes, with backlinks for maximum ease of use in ebook devices.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Dropcaps",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 1,
+      "runs": [
+        {
+          "text": "D",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 58.5,
+          "position": -10,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "spacing": {
+        "line": 951,
+        "lineRule": "exact"
+      },
+      "verticalAlignment": "auto"
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "rop caps are used to emphasize the leading paragraph at the start of a section. In Word it is possible to s",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "p",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "ecify how many lines of text a drop-cap should use. Because of limitations in ebook technology, this is not possible when converting.  Instead, the converted drop cap will use font size and line height to simulate the effect as well as possible. While not as good as the original, the result is usually tolerable. This paragraph has a “D” dropcap set to occupy three lines of text with a font size of 58.5 pts.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " Depending on the screen width and capabilities of the device you view the book on, this dropcap can look anything from perfect to ugly.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "indentation": {
+        "firstLine": 0
+      }
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Links",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Two kinds of links are possible, those that refer to an external website and those that refer to ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "locations",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " inside the document itself. Both are supported by calibre. For example, here is a link pointing to the ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "calibre download page",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "link": "http://calibre-ebook.com/download",
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ".",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " Then we have a link that points back to the section on ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "paragraph level formatting",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " in this document.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Table of Contents",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "There are two approaches that calibre takes when generating a Table of Contents. The first is if the Word document has a Table of Contents itself. Provided that the Table of Contents uses hyperlinks, calibre will automatically use it. The levels of the Table of Contents are identified by their left indent, so if you want the ebook to have a multi-level Table of Contents, make sure you create a properly indented Table of Contents in Word.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "If no Table of Contents is found in the document, then a",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " table of contents is automatically generated from the headings in the document. A heading is identified as something that has the Heading 1 or Heading 2, etc. style applied to it. These headings are turned into a Table of Contents with Heading 1 being the topmost level, Heading 2 the second level and so on.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": " You can see the",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " Table of Contents",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " created by calibre",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " by clicking the Table of Contents button in whatever viewer you are using to view the converted ebook.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Demonstration of DOCX support in calibre",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "1",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Text Formatting",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "2",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Inline formatting",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "2",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Fun with fonts",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "2",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Paragraph level formatting",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "2",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Tables",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "3",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Structural Elements",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "5",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Footnotes & Endnotes",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "5",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Dropcaps",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "5",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Links",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "5",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Table of Contents",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "5",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Images",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "7",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Lists",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "8",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Bulleted List",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "8",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Numbered List",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "8",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Multi-level Lists",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "8",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Continued Lists",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "\t",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "8",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "fontSize": 12,
+          "fontSizeCs": 12,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": []
+    },
+    {
+      "type": "paragraph",
+      "runs": []
+    },
+    {
+      "type": "heading",
+      "level": 1,
+      "runs": [
+        {
+          "text": "Images",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Images can be of three main types. Inline images are images that are part of the normal text flow, like this image of a green dot ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ". Inline images do not cause breaks in the text and are usually small in size.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " The next category of image is a floating image, one that “floats “ on the page and is surrounded by text. Word supports more types of floating images than are possible with current ebook technology, so the conversion maps floating images to simple left and right floats, as you can see with the left and right arrow images on the sides of this paragraph.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "images": [
+        {
+          "type": "image",
+          "data": {},
+          "mimeType": "image/png",
+          "width": 14,
+          "height": 14,
+          "alt": "dot_green.png"
+        },
+        {
+          "type": "image",
+          "data": {},
+          "mimeType": "image/png",
+          "width": 102,
+          "height": 102,
+          "alt": "back.png"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "The final type of image is a “block” image, one that becomes a paragraph on its own and has no text on either side. Below is a centered green dot.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Centered images like this are useful for large pictures that should be a focus of attention.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": " ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "images": [
+        {
+          "type": "image",
+          "data": {},
+          "mimeType": "image/png",
+          "width": 26,
+          "height": 26,
+          "alt": "dot_green.png"
+        },
+        {
+          "type": "image",
+          "data": {},
+          "mimeType": "image/png",
+          "width": 102,
+          "height": 102,
+          "alt": "forward.png"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Generally, it is not possible to translate the exact positioning of images from a Word document to an ebook. That is because in Word, image positioning is specified in absolute units from the page boundaries.  There is no analogous technology in ebooks, so the conversion will usually end up placing the image either centered or floating close to the point in the text where it was ",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "inserted",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": ", not necessarily where it appears on the page in Word.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 1,
+      "runs": [
+        {
+          "text": "Lists",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "All types of lists are supported by the conversion, with the exception of lists that use fancy bullets, these get converted to regular bullets.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Bulleted List",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "One",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "bullet",
+        "text": "",
+        "numFmt": "bullet"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Two",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "bullet",
+        "text": "",
+        "numFmt": "bullet"
+      }
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Numbered List",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "One, with a very long line to demonstrate that the hanging indent for the list is working correctly",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "number",
+        "text": "%1.",
+        "numFmt": "decimal"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Two",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "number",
+        "text": "%1.",
+        "numFmt": "decimal"
+      }
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Multi-level List",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        },
+        {
+          "text": "s",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "One",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "number",
+        "text": "%1.",
+        "numFmt": "decimal"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Two",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 1,
+        "type": "number",
+        "text": "%1.%2.",
+        "numFmt": "decimal"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Three",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 2,
+        "type": "number",
+        "text": "%1.%2.%3.",
+        "numFmt": "decimal"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Four with a very long line to demonstrate that the hanging indent for the list is working correctly.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 2,
+        "type": "number",
+        "text": "%1.%2.%3.",
+        "numFmt": "decimal"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Five",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 2,
+        "type": "number",
+        "text": "%1.%2.%3.",
+        "numFmt": "decimal"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Six",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "number",
+        "text": "%1.",
+        "numFmt": "decimal"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "A Multi-level list with bullets:",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "indentation": {
+        "left": 360,
+        "firstLine": 0
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "One",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "bullet",
+        "text": "",
+        "numFmt": "bullet"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Two",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 1,
+        "type": "bullet",
+        "text": "",
+        "numFmt": "bullet"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "This bullet uses an image as the bullet item",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 2,
+        "type": "bullet",
+        "text": "",
+        "numFmt": "bullet"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Four",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 3,
+        "type": "bullet",
+        "text": "o",
+        "numFmt": "bullet"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Five",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "bullet",
+        "text": "",
+        "numFmt": "bullet"
+      }
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "runs": [
+        {
+          "text": "Continued Lists",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "One",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "number",
+        "text": "%1.",
+        "numFmt": "lowerRoman"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Two",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "number",
+        "text": "%1.",
+        "numFmt": "lowerRoman"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "An interruption in our regularly scheduled listing, for this essential and very relevant public service announcement.",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "indentation": {
+        "firstLine": 0
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "We now resume our normal programming",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "number",
+        "text": "%1.",
+        "numFmt": "lowerRoman"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [
+        {
+          "text": "Four",
+          "bold": false,
+          "italic": false,
+          "underline": false,
+          "strikethrough": false,
+          "superscript": false,
+          "subscript": false,
+          "emboss": false,
+          "imprint": false,
+          "outline": false,
+          "shadow": false,
+          "smallCaps": false,
+          "caps": false,
+          "hidden": false,
+          "doubleStrikethrough": false
+        }
+      ],
+      "listInfo": {
+        "level": 0,
+        "type": "number",
+        "text": "%1.",
+        "numFmt": "lowerRoman"
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": [],
+      "indentation": {
+        "left": 1440,
+        "firstLine": 0
+      }
+    },
+    {
+      "type": "paragraph",
+      "runs": []
+    },
+    {
+      "type": "pageBreak"
+    }
+  ]
+}

--- a/packages/document-types/src/document.ts
+++ b/packages/document-types/src/document.ts
@@ -32,6 +32,7 @@ export interface TextRun {
   highlightColor?: ST_HighlightColor; // OOXML highlight color
   link?: string;
   _footnoteRef?: string;
+  _endnoteRef?: string;
   _fieldCode?: string;
   // Advanced text formatting
   characterSpacing?: number; // Twips
@@ -406,6 +407,18 @@ export interface Footnote {
   elements: (Paragraph | Table)[];
 }
 
+export interface EndnoteReference {
+  type: "endnoteReference";
+  id: string;
+  text: string; // The reference number or marker
+}
+
+export interface Endnote {
+  type: "endnote";
+  id: string;
+  elements: (Paragraph | Table)[];
+}
+
 export type DocumentElement =
   | Paragraph
   | Heading
@@ -417,6 +430,8 @@ export type DocumentElement =
   | Bookmark
   | FootnoteReference
   | Footnote
+  | EndnoteReference
+  | Endnote
   | DrawingObject
   | Shape
   | Chart

--- a/packages/dom-renderer/src/footnote-utils.ts
+++ b/packages/dom-renderer/src/footnote-utils.ts
@@ -1,4 +1,4 @@
-import type { Footnote, FootnoteReference } from "@browser-document-viewer/parser";
+import type { Footnote, FootnoteReference, Endnote, EndnoteReference } from "@browser-document-viewer/parser";
 
 export function getFootnoteDisplayNumber(
   footnoteId: string,
@@ -89,6 +89,109 @@ export function createFootnoteSection(
     // Footnote contains elements (paragraphs, tables) not runs
     if (footnote.elements && footnote.elements.length > 0) {
       footnote.elements.forEach((element) => {
+        const rendered = renderElement(element);
+        if (rendered) {
+          content.appendChild(rendered);
+        }
+      });
+    }
+    item.appendChild(content);
+
+    section.appendChild(item);
+  });
+
+  return section;
+}
+
+export function getEndnoteDisplayNumber(
+  endnoteId: string,
+  endnoteMap: Map<string, Endnote>,
+): number {
+  // Create a sorted list of endnote IDs for consistent numbering
+  const sortedIds = Array.from(endnoteMap.keys()).sort((a, b) => {
+    // Try to parse as numbers first, fall back to string comparison
+    const numA = parseInt(a, 10);
+    const numB = parseInt(b, 10);
+
+    if (!isNaN(numA) && !isNaN(numB)) {
+      return numA - numB;
+    }
+
+    return a.localeCompare(b);
+  });
+
+  const index = sortedIds.indexOf(endnoteId);
+  return index >= 0 ? index + 1 : 1; // 1-based numbering
+}
+
+export function createEndnoteReference(
+  ref: EndnoteReference,
+  doc: Document,
+  endnoteMap: Map<string, Endnote>,
+): HTMLElement {
+  const sup = doc.createElement("sup");
+  const link = doc.createElement("a");
+  link.className = "endnote-marker";
+  link.href = `#endnote-${ref.id}`;
+  link.setAttribute("role", "doc-noteref");
+  link.setAttribute("aria-describedby", `endnote-${ref.id}`);
+
+  // Convert endnote ID to 1-based numbering for display
+  const displayNumber = getEndnoteDisplayNumber(ref.id, endnoteMap);
+  link.textContent = displayNumber.toString();
+  link.title = `Jump to endnote ${displayNumber}`;
+  link.setAttribute("aria-label", `Endnote ${displayNumber}`);
+
+  // Add click handler for smooth scrolling
+  link.onclick = (e) => {
+    e.preventDefault();
+    const endnote = doc.getElementById(`endnote-${ref.id}`);
+    if (endnote) {
+      endnote.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
+  sup.appendChild(link);
+  return sup;
+}
+
+export function createEndnoteSection(
+  endnoteMap: Map<string, Endnote>,
+  doc: Document,
+  renderElement: (element: any) => HTMLElement | null,
+): HTMLElement | null {
+  if (endnoteMap.size === 0) return null;
+
+  const section = doc.createElement("aside");
+  section.className = "endnote-section";
+  section.setAttribute("aria-label", "Endnotes");
+  section.setAttribute("role", "doc-endnotes");
+
+  const heading = doc.createElement("h3");
+  heading.textContent = "Endnotes";
+  heading.className = "text-lg font-semibold mb-2";
+  heading.id = "endnotes-heading";
+  section.appendChild(heading);
+
+  Array.from(endnoteMap.values()).forEach((endnote) => {
+    const item = doc.createElement("div");
+    item.className = "endnote-item";
+    item.id = `endnote-${endnote.id}`;
+    item.setAttribute("role", "doc-endnote");
+    item.setAttribute("aria-describedby", "endnotes-heading");
+
+    const number = doc.createElement("span");
+    number.className = "endnote-number";
+    number.setAttribute("aria-label", "Endnote number");
+    // Convert endnote ID to 1-based numbering for display
+    const displayNumber = getEndnoteDisplayNumber(endnote.id, endnoteMap);
+    number.textContent = `${displayNumber}.`;
+    item.appendChild(number);
+
+    const content = doc.createElement("span");
+    // Endnote contains elements (paragraphs, tables) not runs
+    if (endnote.elements && endnote.elements.length > 0) {
+      endnote.elements.forEach((element) => {
         const rendered = renderElement(element);
         if (rendered) {
           content.appendChild(rendered);

--- a/packages/dom-renderer/src/styles.ts
+++ b/packages/dom-renderer/src/styles.ts
@@ -72,6 +72,35 @@ export function addStyles(): void {
       flex: 1;
     }
     
+    .endnote-marker {
+      color: #3b82f6;
+      text-decoration: none;
+      font-weight: 500;
+    }
+    
+    .endnote-marker:hover {
+      text-decoration: underline;
+    }
+    
+    .endnote-section {
+      margin-top: 2rem;
+      padding-top: 1rem;
+      border-top: 1px solid #ccc;
+    }
+    
+    .endnote-item {
+      margin-bottom: 0.5rem;
+      display: flex;
+      gap: 0.5rem;
+    }
+    
+    .endnote-number {
+      font-weight: 600;
+      color: #374151;
+      min-width: 1.5rem;
+      flex-shrink: 0;
+    }
+    
     .bookmark-anchor {
       display: inline-block;
       width: 0;

--- a/packages/dom-renderer/src/text-renderer.ts
+++ b/packages/dom-renderer/src/text-renderer.ts
@@ -76,6 +76,21 @@ export function renderTextRun(
     return link;
   }
 
+  // Check for endnote reference
+  if ((run as any)._endnoteRef) {
+    const endnoteId = (run as any)._endnoteRef;
+    const link = doc.createElement("a");
+    link.href = `#endnote-${endnoteId}`;
+    link.className = "endnote-marker";
+    link.setAttribute("data-endnote-id", endnoteId);
+
+    const sup = doc.createElement("sup");
+    sup.textContent = run.text;
+    link.appendChild(sup);
+
+    return link;
+  }
+
   let element: HTMLElement;
 
   // Handle links

--- a/packages/parser/src/types/document.ts
+++ b/packages/parser/src/types/document.ts
@@ -33,6 +33,7 @@ export interface TextRun {
   highlightColor?: ST_HighlightColor; // OOXML highlight color
   link?: string;
   _footnoteRef?: string;
+  _endnoteRef?: string;
   _fieldCode?: string;
   // Advanced text formatting
   characterSpacing?: number; // Twips
@@ -407,6 +408,18 @@ export interface Footnote {
   elements: (Paragraph | Table)[];
 }
 
+export interface EndnoteReference {
+  type: "endnoteReference";
+  id: string;
+  text: string; // The reference number or marker
+}
+
+export interface Endnote {
+  type: "endnote";
+  id: string;
+  elements: (Paragraph | Table)[];
+}
+
 export type DocumentElement =
   | Paragraph
   | Heading
@@ -418,6 +431,8 @@ export type DocumentElement =
   | Bookmark
   | FootnoteReference
   | Footnote
+  | EndnoteReference
+  | Endnote
   | DrawingObject
   | Shape
   | Chart


### PR DESCRIPTION
Implements comprehensive endnotes support for DOCX documents in the browser-document-viewer.

## Summary
• Added endnote types and parsing support for DOCX format
• Implemented endnote rendering for both Read Mode (markdown) and View Mode (DOM)
• Added endnote CSS styling and accessibility support
• Maintained all existing test coverage thresholds

## Test plan
• [x] Verify all existing tests pass
• [x] Verify parser tests pass (212 tests, 86.19% function coverage)
• [x] Verify markdown renderer tests pass (36 tests, 84.54% function coverage)
• [x] Verify DOM renderer tests pass (116 tests, 76.93% function coverage)
• [x] Verify build succeeds without errors
• [ ] Test endnotes functionality with DOCX files containing endnotes
• [ ] Verify endnotes render correctly in both Read and View modes
• [ ] Test endnote reference links and smooth scrolling

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)