### PR TITLE
fix: ensure Claude Code review runs only after CI passes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,17 +1,23 @@
 name: Claude Code Review
 
+# This workflow runs after the CI workflow completes successfully
+# This ensures Claude Code review only runs on code that passes all checks
+# (lint, typecheck, unit tests, E2E tests)
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - '**'  # Run on all branches
 
 jobs:
   claude-review:
+    # Only run if the CI workflow succeeded and it's a pull request
+    # This prevents Claude from reviewing code that has failing tests or type errors
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -27,10 +33,29 @@ jobs:
       actions: read       # For reading CI results
     
     steps:
+      # Get PR details from the workflow run
+      - name: Get PR details
+        id: pr-details
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflowRun = context.payload.workflow_run;
+            const prNumber = workflowRun.pull_requests[0]?.number;
+            
+            if (!prNumber) {
+              core.setFailed('No pull request found for this workflow run');
+              return;
+            }
+            
+            core.setOutput('pr_number', prNumber);
+            console.log(`Found PR #${prNumber}`);
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          # Check out the PR branch
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
## Summary
- Changed Claude Code review workflow from `pull_request` trigger to `workflow_run` trigger
- Now waits for all CI checks (lint, typecheck, unit tests, E2E tests) to pass before reviewing
- Prevents wasting Claude API calls on code with failing tests or type errors

## Changes
- Updated `.github/workflows/claude-code-review.yml` to use `workflow_run` trigger
- Added conditional check to only run on successful CI runs for pull requests  
- Added PR details extraction from workflow run context to get PR number

## Benefits
- Saves Claude API usage by not reviewing code that doesn't pass basic checks
- Ensures Claude reviews are focused on code quality rather than catching basic errors
- More efficient CI pipeline with proper dependency chain

🤖 Generated with [Claude Code](https://claude.ai/code)