### PR TITLE
docs: add SheetJS and libetonyek to See also section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ All output files are saved to the `tmp` directory which is ignored by git.
 * [mammoth.js](https://github.com/mwilliamson/mammoth.js)
 * [docxjs](https://github.com/VolodymyrBaydalka/docxjs)
 * [SheetJS](https://git.sheetjs.com/sheetjs/sheetjs)
+* [libetonyek](https://github.com/LibreOffice/libetonyek)

--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ All output files are saved to the `tmp` directory which is ignored by git.
 
 * [mammoth.js](https://github.com/mwilliamson/mammoth.js)
 * [docxjs](https://github.com/VolodymyrBaydalka/docxjs)
+* [SheetJS](https://git.sheetjs.com/sheetjs/sheetjs)


### PR DESCRIPTION
## Summary

- Added [SheetJS](https://git.sheetjs.com/sheetjs/sheetjs) to the See also section
- Added [libetonyek](https://github.com/LibreOffice/libetonyek) to the See also section

These are relevant document parsing/processing libraries that users might find helpful as alternatives or complementary tools.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>